### PR TITLE
nMOSにしきい電圧の温度係数KT1を追加

### DIFF
--- a/16PTS/mos_PTS06.lib
+++ b/16PTS/mos_PTS06.lib
@@ -1,5 +1,5 @@
 ** Phenitec Mos spice model
-** ver1.00 by arugak  (170813)
+** ver1.01 by arugak and keikawa (220313)
 *
 .MODEL nchOR1ex NMOS
 + LEVEL    = 8
@@ -117,6 +117,7 @@
 + CJ      = 0.000678126 
 + CF      = 0           
 + CJSW    = 2.61022E-10 
++ KT1     = -0.27
 *
 .MODEL pchOR1ex PMOS
 + LEVEL    = 8


### PR DESCRIPTION
[温度センサ回路](https://github.com/keikawa/temperature-sensor-OpenRule1um)の出力電圧の温度係数が測定とシミュレーションとで一致するように、nMOSにしきい電圧の温度係数KT1を追加しました。
以下は測定結果とKT1追加前後のシミュレーション結果です。

![temp_sens](https://user-images.githubusercontent.com/37934321/158051093-80edf283-52f9-497e-a6ab-87607ed9bfab.png)
